### PR TITLE
CI: upgrade FreeBSD version to avoid future breakage

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -5,9 +5,9 @@ env:
 task:
   freebsd_instance:
     matrix:
-      image_family: freebsd-13-0-snap
-      image_family: freebsd-12-1
-      image: freebsd-11-3-stable-amd64-v20190801
+      image_family: freebsd-14-0-snap
+      image_family: freebsd-13-1
+      image_family: freebsd-12-3
   install_script:
     - sed -i.bak -e 's,quarterly,latest,' /etc/pkg/FreeBSD.conf
     - env ASSUME_ALWAYS_YES=yes pkg bootstrap -f


### PR DESCRIPTION
FreeBSD Project currently doesn't keep recent binary packages for EOL versions. `/release_0` packages (non-default) frozen at 13.0 release (2021-04-13) will remain after 13.0 EOL (2022-08-31) for 13.* branch lifetime (until 2026-01-31) but maybe too old for libudev-devd CI.

Note, `.cirrus.yml` is currently [not enabled](https://github.com/marketplace/cirrus-ci), so see https://github.com/jbeich/libudev-devd/runs/7330379557
