### PR TITLE
Update udev_device_unref() signature to match contemporary libudev.

### DIFF
--- a/libudev.h
+++ b/libudev.h
@@ -38,7 +38,7 @@ struct udev_device *udev_device_new_from_device_id(struct udev *udev,
     const char *id);
 struct udev_device *udev_device_new_from_environment(struct udev *udev);
 struct udev_device *udev_device_ref(struct udev_device *udev_device);
-void udev_device_unref(struct udev_device *udev_device);
+struct udev_device *udev_device_unref(struct udev_device *udev_device);
 char const *udev_device_get_devnode(struct udev_device *udev_device);
 char const *udev_device_get_devpath(struct udev_device *udev_device);
 char const *udev_device_get_property_value(struct udev_device *udev_device,

--- a/udev-device.c
+++ b/udev-device.c
@@ -341,12 +341,13 @@ udev_device_free(struct udev_device *ud)
 	free(ud);
 }
 
-LIBUDEV_EXPORT void
+LIBUDEV_EXPORT struct udev_device *
 udev_device_unref(struct udev_device *ud)
 {
 	TRC("(%p/%s) %d", ud, ud->syspath, ud->refcount);
 	if (--ud->refcount == 0)
 		udev_device_free(ud);
+	return (NULL);
 }
 
 LIBUDEV_EXPORT struct udev_device *


### PR DESCRIPTION
Man page: https://manpages.debian.org/testing/libudev-dev/udev_device_unref.3.en.html

Required for new PipeWire.