### PR TITLE
Fix the build with _FORTIFY_SOURCE enabled

### DIFF
--- a/utils.h
+++ b/utils.h
@@ -8,6 +8,8 @@
 #include <string.h>
 #include <unistd.h>
 
+#include "config.h"
+
 #ifdef HAVE_SYS_TREE_H
 #include <sys/tree.h>
 #else


### PR DESCRIPTION
util.h uses various HAVE_ macros that are defined in config.h. Currently everyone needs to include it beforehand, but it's much safer to just include it directory in utils.h to avoid some declarations that may conflict with system headers.

This fixes both _FORTIFY_SOURCE and an inconsistent declaration of pipe2(2) that I hit while trying to build libudev-devd originally.