### PR TITLE
Bump version number to 0.7.0

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@ AC_PREREQ([2.64])
 
 m4_define([libudev_version], [243])
 
-AC_INIT([libudev],[0.6.0],[https://github.com/wulf7/libudev-devd],[libudev-devd])
+AC_INIT([libudev],[0.7.0],[https://github.com/wulf7/libudev-devd],[libudev-devd])
 AC_CONFIG_HEADERS([config.h])
 AC_CONFIG_AUX_DIR([ac-aux])
 AC_CONFIG_MACRO_DIR([m4])

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('libudev-devd', 'c',
-	version : '0.6.0',
+	version : '0.7.0',
 	license : 'BSD2CLAUSE',
 	default_options : [
 		'buildtype=debugoptimized',


### PR DESCRIPTION
To enable a cleaner upgrade of the port. Please generate the GitHub Release.